### PR TITLE
Override __eq__ for sql objects, update tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ lint: venv
 	venv/bin/flake8 src tests
 
 unit_test: venv
-	venv/bin/py.test -vvvv -r sxX tests
+	venv/bin/py.test -vvvv -r sxX tests/test_unit.py
 
-test: venv unit_test
+e2e_test: venv
+	venv/bin/py.test -vvvv -r sxX tests/test_e2e.py
+
+test: venv unit_test e2e_test

--- a/output/cmd.py
+++ b/output/cmd.py
@@ -17,7 +17,7 @@ def beautify(results: List[Procedure]) -> None:
         msg += f'\n\n{Fore.GREEN}----------------------------\n'
         msg += f'{Fore.GREEN}{p.schema}.{p.name} ({p.path})\n'
         msg += f'{Fore.GREEN}----------------------------\n{Style.RESET_ALL}'
-        for q in p.queries:
+        for q in p.statements:
             msg += f'|\n|--- {Fore.BLUE}{q.operation}{Style.RESET_ALL} ' \
                    f'----> {Fore.CYAN}{q.target_table.schema}.{q.target_table.name}\n{Style.RESET_ALL}'
 

--- a/output/json.py
+++ b/output/json.py
@@ -16,7 +16,7 @@ def to_json(results: List[Procedure], path: str) -> None:
     to_dict = dict()
     for p in results:
         to_dict[p.name] = p.__dict__
-        to_dict[p.name]['queries'] = [q.__dict__ for q in p.queries]
+        to_dict[p.name]['queries'] = [q.__dict__ for q in p.statements]
 
     with open(path, 'w') as fp:
         ujson.dump(to_dict, fp, indent=4, sort_keys=True)

--- a/sql/objects.py
+++ b/sql/objects.py
@@ -1,15 +1,25 @@
 
 class Procedure:
 
-    def __init__(self, path, name=None, schema=None, queries=None):
+    def __init__(self, path, name=None, schema=None, statements=None):
 
         self.name = name
         self.schema = schema
         self.path = path
-        self.queries = queries
+        self.statements = statements
+
+    def __eq__(self, other):
+
+        if isinstance(other, Procedure):
+            return (self.name == other.name
+                    and self.schema == other.schema
+                    and self.path == other.path
+                    and self.statements == other.statements)
+
+        return False
 
 
-class Query:
+class Statement:
 
     def __init__(self,
                  procedure=None,
@@ -29,6 +39,19 @@ class Query:
         self.target_table = target_table
         self.target_columns = target_columns
 
+    def __eq__(self, other):
+
+        if isinstance(other, Statement):
+
+            return (self.procedure == other.procedure
+                    and self.operation == other.operation
+                    and self.from_table == other.from_table
+                    and self.join_table == other.join_table
+                    and self.target_table == other.target_table
+                    and self.target_columns == other.target_columns)
+
+        return False
+
 
 class Table:
 
@@ -36,3 +59,10 @@ class Table:
 
         self.name = name
         self.schema = schema
+
+    def __eq__(self, other):
+
+        if isinstance(other, Table):
+            return self.name == other.name and self.schema == other.schema
+
+        return False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,9 @@
+
+def test_parse_dir():
+
+    pass
+
+
+def test_parse_file():
+
+    pass

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,71 @@
+from sql.objects import Procedure, Statement, Table
+from sqlparse import format as fmt
+
+procedure_path = './tests/resources/procedure.sql'
+insert_path = './tests/resources/insert.sql'
+update_path = './tests/resources/update.sql'
+delete_path = './tests/resources/delete.sql'
+
+# NB: Antlr grammar is case-sensitive. Input has to be upper case.
+# Open and upper case test procedure file
+with open(procedure_path, 'r') as file:
+    TEST_PROCEDURE = fmt(file.read().upper(), strip_comments=True).strip()
+
+# Open and upper case test insert statement
+with open(insert_path, 'r') as file:
+    TEST_INSERT_STATEMENT = fmt(file.read().upper(), strip_comments=True).strip()
+
+# Open and upper case test update statement
+with open(update_path, 'r') as file:
+    TEST_UPDATE_STATEMENT = fmt(file.read().upper(), strip_comments=True).strip()
+
+# Open and upper case test delete statement
+with open(delete_path, 'r') as file:
+    TEST_DELETE_STATEMENT = fmt(file.read().upper(), strip_comments=True).strip()
+
+TEST_DEFAULT_SCHEMA = 'default_schema'
+TEST_DELIMITER = ';;'
+TEST_MODE = 'procedure'
+
+INSERT_STATEMENT_EXPECTED = Statement(procedure=None,
+                                      operation='INSERT',
+                                      from_table=[Table(name='src_tab_1', schema=TEST_DEFAULT_SCHEMA)],
+                                      join_table=[Table(name='src_tab_2', schema=TEST_DEFAULT_SCHEMA),
+                                                  Table(name='src_tab_3', schema=TEST_DEFAULT_SCHEMA)],
+                                      target_table=Table(name='mytable', schema=TEST_DEFAULT_SCHEMA),
+                                      target_columns=['col_1', 'col_2', 'col_3', 'col_4', 'col_5', 'col_6', 'col_7'])
+
+UPDATE_STATEMENT_EXPECTED = Statement(procedure=None,
+                                      operation='UPDATE',
+                                      join_table=[Table(name='src_tab_9', schema=TEST_DEFAULT_SCHEMA)],
+                                      target_table=Table(name='src_tab_8', schema=TEST_DEFAULT_SCHEMA),
+                                      target_columns=['tab_8.col_3=tab_9.col4', 'tab_8.col_4=tab_9.col5'])
+
+DELETE_STATEMENT_EXPECTED = Statement(procedure=None,
+                                      operation='DELETE',
+                                      target_table=Table(name='src_tab_10', schema=TEST_DEFAULT_SCHEMA))
+
+INSERT_EXPECTED = Statement(procedure='testproc',
+                            operation='INSERT',
+                            from_table=[Table(name='src_tab_1', schema=TEST_DEFAULT_SCHEMA)],
+                            join_table=[Table(name='src_tab_2', schema=TEST_DEFAULT_SCHEMA),
+                                    Table(name='src_tab_3', schema=TEST_DEFAULT_SCHEMA)],
+                            target_table=Table(name='mytable', schema=TEST_DEFAULT_SCHEMA),
+                            target_columns=['col_1', 'col_2', 'col_3', 'col_4', 'col_5', 'col_6', 'col_7'])
+
+UPDATE_EXPECTED = Statement(procedure='testproc',
+                            operation='UPDATE',
+                            join_table=[Table(name='src_tab_9', schema=TEST_DEFAULT_SCHEMA)],
+                            target_table=Table(name='src_tab_8', schema=TEST_DEFAULT_SCHEMA),
+                            target_columns=['tab_8.col_3=tab_9.col4', 'tab_8.col_4=tab_9.col5'])
+
+DELETE_EXPECTED = Statement(procedure='testproc',
+                            operation='DELETE',
+                            target_table=Table(name='src_tab_10', schema=TEST_DEFAULT_SCHEMA))
+
+
+PROCEDURE_EXPECTED = Procedure(path=procedure_path,
+                               name='testproc',
+                               schema='example',
+                               statements=[INSERT_EXPECTED, UPDATE_EXPECTED, DELETE_EXPECTED])
+


### PR DESCRIPTION
**Changes proposed in this PR:**

-> Override __eq__ for SQL objects, renaming
-> Update references accordingly
-> Simplify tests, add equality check test